### PR TITLE
remove unused import which is imcompitible with python3.6 and below

### DIFF
--- a/rchain/util.py
+++ b/rchain/util.py
@@ -1,6 +1,4 @@
 import time
-import string
-import importlib.resources
 
 from .crypto import PrivateKey
 from .pb.CasperMessage_pb2 import DeployData


### PR DESCRIPTION
@adaszko Just want to tell you these import wasn't removed. 